### PR TITLE
Indicate own happiness and enabled notifications for users as reminders

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist",
     "slate": "rimraf node_modules && npm install",
     "lint": "eslint client server",
-    "heroku-prebuild": "npm run build:server && npm run build && npm install",
+    "heroku-prebuild": "npm run build:server && npm run build",
     "heroku-postbuild": ""
   },
   "pre-commit": [],

--- a/server/controllers/postponeNotification.controller.js
+++ b/server/controllers/postponeNotification.controller.js
@@ -63,7 +63,7 @@ export function postponeNotification(req, res) {
     // postpone notification
     const postponeTime = parseInt(requestedPostponeTime, 0);
     const postponeTimeInMilliseconds = getPostponeTimeInMilliseconds(restTimeForUserToPostpone, postponeTime);
-    increasePostponedTimeForUser(user, postponeTimeInMilliseconds);
-    timedNotificationTask.postponeNotificationForUser(user.id, postponeTime);
+    increasePostponedTimeForUser(user, postponeTime);
+    timedNotificationTask.postponeNotificationForUser(user.id, postponeTimeInMilliseconds);
   });
 }

--- a/server/controllers/postponeNotification.controller.js
+++ b/server/controllers/postponeNotification.controller.js
@@ -10,10 +10,10 @@ export function messageContentIs5_or_10_or_20(message) {
   return postponeTime !== 0 && permittedDelays.includes(postponeTime);
 }
 
-function increasePostponedTimeForUser(user, postponeTimeInMilliseconds) {
+function increasePostponedTimeForUser(user, postponeTime) {
   const storedPostponeTime = typeof user.postponeTimeInMilliseconds !== 'undefined' ? user.postponeTimeInMilliseconds : 0;
-  user.postponeTimeInMilliseconds = storedPostponeTime + postponeTimeInMilliseconds;
-  user.save();
+  user.postponedTimeForSchedule = storedPostponeTime + postponeTime;
+  user.save().exec();
 }
 
 export function getPostponeTimeInMilliseconds(restTimeForUserToPostpone, requestedPostponeTime) {
@@ -65,5 +65,6 @@ export function postponeNotification(req, res) {
     const postponeTimeInMilliseconds = getPostponeTimeInMilliseconds(restTimeForUserToPostpone, postponeTime);
     increasePostponedTimeForUser(user, postponeTime);
     timedNotificationTask.postponeNotificationForUser(user.id, postponeTimeInMilliseconds);
+    res.send({ success: true });
   });
 }

--- a/server/controllers/postponeNotification.controller.js
+++ b/server/controllers/postponeNotification.controller.js
@@ -4,8 +4,10 @@ import notification from '../util/notification';
 import timedNotificationTask from '../util/timedNotificaionTask';
 
 export function messageContentIs5_or_10_or_20(message) {
-  const permittedDelays = ['5', '10', '20'];
-  return message !== 'undefined' && permittedDelays.includes(message);
+  const permittedDelays = [5, 10, 20];
+  if (message === 'undefined') return false;
+  const postponeTime = parseInt(message, 0);
+  return postponeTime !== 0 && permittedDelays.includes(message);
 }
 
 function increasePostponedTimeForUser(user, postponeTimeInMilliseconds) {

--- a/server/controllers/postponeNotification.controller.js
+++ b/server/controllers/postponeNotification.controller.js
@@ -7,7 +7,7 @@ export function messageContentIs5_or_10_or_20(message) {
   const permittedDelays = [5, 10, 20];
   if (message === 'undefined') return false;
   const postponeTime = parseInt(message, 0);
-  return postponeTime !== 0 && permittedDelays.includes(message);
+  return postponeTime !== 0 && permittedDelays.includes(postponeTime);
 }
 
 function increasePostponedTimeForUser(user, postponeTimeInMilliseconds) {
@@ -60,7 +60,8 @@ export function postponeNotification(req, res) {
       return;
     }
     // postpone notification
-    const postponeTimeInMilliseconds = getPostponeTimeInMilliseconds(restTimeForUserToPostpone, requestedPostponeTime);
+    const postponeTime = parseInt(requestedPostponeTime, 0);
+    const postponeTimeInMilliseconds = getPostponeTimeInMilliseconds(restTimeForUserToPostpone, postponeTime);
     increasePostponedTimeForUser(user, postponeTimeInMilliseconds);
     timedNotificationTask.postponeNotificationForUser(user.id, postponeTimeInMilliseconds);
   });

--- a/server/controllers/postponeNotification.controller.js
+++ b/server/controllers/postponeNotification.controller.js
@@ -11,7 +11,8 @@ export function messageContentIs5_or_10_or_20(message) {
 }
 
 function increasePostponedTimeForUser(user, postponeTimeInMilliseconds) {
-  user.postponedTimeForSchedule += postponeTimeInMilliseconds;
+  const storedPostponeTime = typeof user.postponeTimeInMilliseconds !== 'undefined' ? user.postponeTimeInMilliseconds : 0;
+  user.postponeTimeInMilliseconds = storedPostponeTime + postponeTimeInMilliseconds;
   user.save();
 }
 
@@ -52,7 +53,7 @@ export function postponeNotification(req, res) {
       return;
     }
     // postpone time exceeded?
-    const usersPostponedTimeForSchedule = user.postponedTimeForSchedule !== 'undefined' && user.postponedTimeForSchedule !== null ? user.postponedTimeForSchedule : 0;
+    const usersPostponedTimeForSchedule = typeof user.postponedTimeForSchedule !== 'undefined' && user.postponedTimeForSchedule !== null ? user.postponedTimeForSchedule : 0;
     const restTimeForUserToPostpone = maximumPostponeTimeForOneSchedule - usersPostponedTimeForSchedule;
     if (restTimeForUserToPostpone === 0) {
       notification.sendTextMessage(postponeTimeExceededMessage, userPhoneNumber, twilioPhoneNumber, () => {});
@@ -63,6 +64,6 @@ export function postponeNotification(req, res) {
     const postponeTime = parseInt(requestedPostponeTime, 0);
     const postponeTimeInMilliseconds = getPostponeTimeInMilliseconds(restTimeForUserToPostpone, postponeTime);
     increasePostponedTimeForUser(user, postponeTimeInMilliseconds);
-    timedNotificationTask.postponeNotificationForUser(user.id, postponeTimeInMilliseconds);
+    timedNotificationTask.postponeNotificationForUser(user.id, postponeTime);
   });
 }

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -6,7 +6,7 @@ const userSchema = new Schema({
   name: { type: 'String', required: true },
   phone: { type: 'String', required: false },
   email: { type: 'String', required: false },
-  postponedTimeForSchedule: { type: 'Number', required: false },
+  postponedTimeForSchedule: { type: 'Number', required: false, default: 0 },
   team: { type: Schema.Types.ObjectId, required: false, ref: 'Team' },
 });
 


### PR DESCRIPTION
Resolved the following stories in this branch:
As a team member I want to indicate how happy I am
As a team member I want to indicate how happy the team is
As a team member I want to input my happiness on a small scale to more easily decide for a value
As a team member I want to have fewer steps and better descriptions during input to save time
As a team member I want to be reminded to input my happiness at different times each day to not get biased (_Restriction: Feature is not enabled yet, due to an error when deploying it to heroku_)
As a team member I want to be reminded regularly when ignoring the notification to not forget the input (_Restriction: Notifications don't yet stop an hour before the next notification schedule starts_)
As a team member I want to postpone notifications to be not disturbed during busy work hours